### PR TITLE
Add documentation with Documenter.jl and Literate.jl

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+  statuses: write
+jobs:
+  build:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
+        with:
+          version: '1'
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38
+      - name: Install dependencies
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # authentication for same-repo deploys / PR previews
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}  # SSH deploy key (preferred; enables fork PR previews)
+        run: julia --project=docs docs/make.jl

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -24,6 +24,6 @@ jobs:
         run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # authentication for same-repo deploys / PR previews
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}  # SSH deploy key (preferred; enables fork PR previews)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # authentication for same-repo deploys and PR previews
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}  # SSH deploy key (preferred: its pushes trigger a GitHub Pages rebuild, unlike GITHUB_TOKEN). Secrets are unavailable to PRs from forks, so neither enables fork previews.
         run: julia --project=docs docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ deps/src/
 docs/build/
 docs/site/
 pluto/
+
+# files generated automatically by Literate.jl
+docs/src/literate/*.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # LatticeProteins.jl
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/LatticeProteins.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/LatticeProteins.jl/dev/)
+
 Simulate the lattice proteins model on a 3×3×3 cubic lattice in Julia.
 
 In this model, a protein is represented as a chain of 27 amino acids that folds on a 3×3×3 cubic lattice. The energy of a sequence in a given structure is determined by pairwise contacts between amino acids using the Miyazawa-Jernigan interaction matrix. The probability that a sequence folds into a given "native" structure is computed via a Boltzmann distribution over 10,000 pre-computed compact structures.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LatticeProteins = "2b3394db-9f9c-454f-a26a-0ad872321417"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+
+[compat]
+Documenter = "1"
+Literate = "2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,34 @@
+import Documenter
+import Literate
+import LatticeProteins
+
+# Run Literate.jl over the tutorial sources, generating Markdown files next to
+# them. The generated `.md` files are git-ignored (see `.gitignore`).
+const literate_dir = joinpath(@__DIR__, "src", "literate")
+for file in readdir(literate_dir; join = true)
+    if endswith(file, ".jl")
+        Literate.markdown(file, literate_dir; documenter = true)
+    end
+end
+
+Documenter.makedocs(
+    modules = [LatticeProteins],
+    sitename = "LatticeProteins.jl",
+    authors = "Jorge Fernandez-de-Cossio-Diaz",
+    repo = Documenter.Remotes.GitHub("cossio", "LatticeProteins.jl"),
+    pages = [
+        "Home" => "index.md",
+        "Tutorial" => "literate/tutorial.md",
+        "Reference" => "reference.md",
+    ],
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://cossio.github.io/LatticeProteins.jl/stable/",
+    ),
+)
+
+Documenter.deploydocs(
+    repo = "github.com/cossio/LatticeProteins.jl.git",
+    devbranch = "main",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,63 @@
+# LatticeProteins.jl
+
+Simulate the lattice proteins model on a 3×3×3 cubic lattice in Julia.
+
+In this model, a protein is represented as a chain of 27 amino acids that folds on
+a 3×3×3 cubic lattice. The energy of a sequence in a given structure is determined by
+pairwise contacts between amino acids using the Miyazawa-Jernigan interaction matrix.
+The probability that a sequence folds into a given "native" structure is computed via a
+Boltzmann distribution over 10,000 pre-computed compact structures.
+
+This package does not export any symbols; everything is accessed either with the
+`LatticeProteins.` prefix or by importing the names explicitly, e.g.
+`using LatticeProteins: pnat, energy`.
+
+## Installation
+
+This package is registered. Install it with:
+
+```julia
+import Pkg
+Pkg.add("LatticeProteins")
+```
+
+## Quick start
+
+```julia
+using LatticeProteins: pnat, energy, onehot, aaseq, potts, random_msa,
+    CONTACT_MAP_A, Hugo_MSA, Hugo_MSA_pnat
+
+# Compute the probability that a sequence folds into structure A
+seq = potts("EKAMPAMDPDMAHEHKKKIRAWMFEGE")  # convert to integer-coded sequence
+p = pnat(CONTACT_MAP_A, seq)
+
+# Compute the contact energy
+E = energy(CONTACT_MAP_A, seq)
+
+# Generate sequences that fold into structure A via Metropolis sampling
+msa = random_msa(CONTACT_MAP_A; nseqs=100, β=100, nsteps=1000)
+```
+
+See the [Tutorial](@ref) for a worked walkthrough and the [Reference](@ref) for the
+full list of functions.
+
+## Contents
+
+```@contents
+Pages = ["literate/tutorial.md", "reference.md"]
+Depth = 2
+```
+
+## Citation
+
+If you use this package, please cite:
+
+Fernandez-de-Cossio-Diaz, Jorge, Clément Roussel, Simona Cocco, and Remi Monasson.
+["Accelerated Sampling with Stacked Restricted Boltzmann Machines."](https://openreview.net/forum?id=kXNJ48Hvw1)
+*The Twelfth International Conference on Learning Representations* (2024).
+
+## References
+
+- Jacquin, Hugo, et al. ["Benchmarking inverse statistical approaches for protein
+  structure and design with exactly solvable models."](https://doi.org/10.1371/journal.pcbi.1004889)
+  *PLoS computational biology* 12.5 (2016): e1004889.

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -4,6 +4,10 @@
 # amino acid sequences, computing contact energies and folding probabilities, and
 # sampling sequences that fold into a target structure.
 
+# ```@meta
+# CurrentModule = LatticeProteins
+# ```
+
 # ## Setup
 #
 # Since the package does not export any symbols, we import the names we need

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -1,0 +1,108 @@
+# # Tutorial
+#
+# This tutorial walks through the main features of `LatticeProteins.jl`: encoding
+# amino acid sequences, computing contact energies and folding probabilities, and
+# sampling sequences that fold into a target structure.
+
+# ## Setup
+#
+# Since the package does not export any symbols, we import the names we need
+# explicitly. (Alternatively, everything is reachable through the `LatticeProteins.`
+# prefix.)
+
+using LatticeProteins: pnat, log_pnat, energy, onehot, aaseq, potts, AMINO_ACIDS,
+    metropolis!, random_msa, CONTACT_MAP_A, CONTACT_MAP_B,
+    CONTACT_MAPS, N_STRUCTURES, MJ, Hugo_MSA, Hugo_MSA_pnat
+
+# A lattice protein is a chain of 27 amino acids folded onto a 3×3×3 cubic lattice.
+# The package ships with 10,000 pre-computed compact structures (contact maps):
+
+N_STRUCTURES
+
+# Four of these structures are highlighted in Jacquin et al. (2016) and exposed as
+# constants `CONTACT_MAP_A`, `CONTACT_MAP_B`, `CONTACT_MAP_C` and `CONTACT_MAP_D`.
+# Each is simply an index into the structure database:
+
+CONTACT_MAP_A
+
+# ## Encoding sequences
+#
+# Sequences are written as strings over the [`AMINO_ACIDS`](@ref) alphabet (20 amino
+# acids plus a gap character):
+
+AMINO_ACIDS
+
+# Most numerical routines work with *integer-coded* (Potts) sequences, where each
+# amino acid is replaced by its index in the alphabet. Use [`potts`](@ref) to convert:
+
+seq = potts("EKAMPAMDPDMAHEHKKKIRAWMFEGE")
+
+# We can convert back to a string with [`aaseq`](@ref):
+
+aaseq(seq)
+
+# A sequence can also be one-hot encoded into a `21 × 27` `BitMatrix` with
+# [`onehot`](@ref), which is convenient for machine-learning workflows:
+
+X = onehot("EKAMPAMDPDMAHEHKKKIRAWMFEGE")
+size(X)
+
+# ## Energy and folding probability
+#
+# The contact [`energy`](@ref) of a sequence in a given structure is the sum of
+# Miyazawa-Jernigan interaction energies over all contacting residue pairs:
+
+energy(CONTACT_MAP_A, seq)
+
+# The same sequence has a different energy in a different structure:
+
+energy(CONTACT_MAP_B, seq)
+
+# The probability that a sequence folds into a particular "native" structure is given
+# by a Boltzmann distribution over all 10,000 competing structures. This is
+# [`pnat`](@ref) (and its logarithm [`log_pnat`](@ref)):
+
+pnat(CONTACT_MAP_A, seq)
+
+#-
+
+log_pnat(CONTACT_MAP_A, seq)
+
+# ## Sampling sequences that fold
+#
+# We can search for sequences that fold into a target structure using Metropolis
+# Monte Carlo. [`random_msa`](@ref) starts from random sequences and evolves each one
+# at inverse temperature `β`; a large `β` strongly favours sequences with high
+# folding probability for the target structure.
+
+msa = random_msa(CONTACT_MAP_A; nseqs = 20, β = 100, nsteps = 200)
+size(msa)
+
+# Each column of the returned matrix is an integer-coded sequence. The sampled
+# sequences fold into structure A with high probability:
+
+using Statistics: mean
+mean(pnat(CONTACT_MAP_A, col) for col in eachcol(msa))
+
+# [`metropolis!`](@ref) exposes the same sampler for a single sequence, mutating it
+# in place:
+
+s = potts("EKAMPAMDPDMAHEHKKKIRAWMFEGE")
+metropolis!(s, CONTACT_MAP_A; β = 100, nsteps = 200)
+pnat(CONTACT_MAP_A, s)
+
+# ## Reference datasets
+#
+# The package also bundles the reference multiple sequence alignments (MSAs) and
+# their folding probabilities from Jacquin et al. (2016), accessible with
+# [`Hugo_MSA`](@ref) and [`Hugo_MSA_pnat`](@ref):
+
+sequences = Hugo_MSA(:A)
+length(sequences)
+
+#-
+
+pnat_values = Hugo_MSA_pnat(:A)
+first(pnat_values, 5)
+
+# See the [Reference](@ref) for the complete list of available functions.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,63 @@
+# Reference
+
+```@meta
+CurrentModule = LatticeProteins
+```
+
+This page documents all symbols provided by `LatticeProteins.jl`. None of them are
+exported, so they must be accessed with the `LatticeProteins.` prefix or imported
+explicitly (e.g. `using LatticeProteins: pnat`).
+
+## Structures and contact maps
+
+```@docs
+CONTACT_MAPS
+N_STRUCTURES
+N_CONTACTS
+L
+CONTACT_MAP_A
+CONTACT_MAP_B
+CONTACT_MAP_C
+CONTACT_MAP_D
+load_contact_maps
+```
+
+## Energy and folding probability
+
+```@docs
+energy
+pnat
+log_pnat
+```
+
+## Sequence encoding
+
+```@docs
+AMINO_ACIDS
+onehot
+potts
+aaseq
+```
+
+## Sampling
+
+```@docs
+metropolis!
+random_msa
+```
+
+## Miyazawa-Jernigan matrix
+
+```@docs
+MJ
+load_miyazawa_jernigan_matrix
+load_miyazawa_jernigan_aminoacids
+```
+
+## Reference data
+
+```@docs
+Hugo_MSA
+Hugo_MSA_pnat
+Hugo_MSA_path
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -8,6 +8,10 @@ This page documents all symbols provided by `LatticeProteins.jl`. None of them a
 exported, so they must be accessed with the `LatticeProteins.` prefix or imported
 explicitly (e.g. `using LatticeProteins: pnat`).
 
+```@docs
+LatticeProteins
+```
+
 ## Structures and contact maps
 
 ```@docs


### PR DESCRIPTION
Sets up a documentation site built with [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl), including a [Literate.jl](https://github.com/fredrikekre/Literate.jl) tutorial, mirroring the workflow used in `Rfam.jl`.

## What's included

| File | Purpose |
|------|---------|
| `docs/make.jl` | Documenter + Literate build pipeline (runs Literate over the tutorial, builds HTML, deploys) |
| `docs/Project.toml` | Docs environment: Documenter, Literate, LatticeProteins |
| `docs/src/index.md` | Landing page: overview, installation, quick start, citation |
| `docs/src/reference.md` | Full API reference — every docstring, grouped by topic |
| `docs/src/literate/tutorial.jl` | Literate.jl walkthrough: encoding, energy/`pnat`, Metropolis sampling, reference MSAs |
| `.github/workflows/Documentation.yml` | Builds & deploys docs on push to `main`, tags, and PRs (with preview) |
| `.gitignore` | Ignores Literate-generated `docs/src/literate/*.md` |

## Notes

- Targets the `main` branch (`devbranch = "main"`).
- Since `LatticeProteins` exports nothing, the docs use explicit imports and the reference page sets `CurrentModule = LatticeProteins`.
- The deploy workflow uses the existing `DOCUMENTER_KEY` secret (already referenced by `TagBot.yml`), with `GITHUB_TOKEN` as fallback — no new secret is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ixFjHUXtnLgJz4AovYW1y)_